### PR TITLE
Fixed BSX-200 LiquidHydrogen Not Generating

### DIFF
--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Distiller_01/KA_Distiller_250_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Distiller_01/KA_Distiller_250_01.cfg
@@ -56,8 +56,7 @@ MODULE
 	 StartActionName = Start LH2/Ox 
   	 StopActionName = Stop LH2/Ox
 	 RecipeInputs = ElectricCharge,6,Karbonite,1
-	 RecipeOutputs = LiquidHydrogen,1.25,False
-	 RecipeOutputs = Oxygen,355,true
+	 RecipeOutputs = LiquidHydrogen,1.25,False,Oxygen,355,true
 }
 
 MODULE
@@ -67,8 +66,7 @@ MODULE
 	 StartActionName = Start Ox/LH2 
   	 StopActionName = Stop Ox/LH2
 	 RecipeInputs = ElectricCharge,6,Karbonite,1
-	 RecipeOutputs = LiquidHydrogen,1.25,true
-	 RecipeOutputs = Oxygen,355,False
+	 RecipeOutputs = LiquidHydrogen,1.25,true,Oxygen,355,False
 }
 
 


### PR DESCRIPTION
The BSX-200 Karbonite Distiller did not generate LF2 in either mode. This fixes that issue.