### PR TITLE
Fix cost of karbonite-fueled Parts

### DIFF
--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_125_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_125_01.cfg
@@ -47,7 +47,8 @@ sound_explosion_low = flameout
 // --- editor parameters ---
 TechRequired = heavyRocketry
 entryCost = 1500
-cost = 150
+// cost = 150 (base cost) + 600 * 1.6 (max fuel * cost per unit)
+cost = 1110
 category = Propulsion
 subcategory = 0
 title = RAT-125-A Karbonite SRB
@@ -65,7 +66,7 @@ maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 7
-maxTemp = 3600 
+maxTemp = 3600
 fuelCrossFeed = false
 
 stagingIcon = SOLID_BOOSTER
@@ -96,7 +97,7 @@ MODULE
    	 key = 0 400
   	 key = 1 400
  	}
-	
+
 }
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_125_02.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_125_02.cfg
@@ -54,7 +54,8 @@ sound_explosion_low = flameout
 // --- editor parameters ---
 TechRequired = heavyRocketry
 entryCost = 1500
-cost = 150
+// cost = 150 (base cost) + 1200 * 1.6 (max fuel * cost per unit)
+cost = 2070
 category = Propulsion
 subcategory = 0
 title = RAT-125-B Karbonite SRB
@@ -72,7 +73,7 @@ maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 7
-maxTemp = 3600 
+maxTemp = 3600
 fuelCrossFeed = false
 
 stagingIcon = SOLID_BOOSTER
@@ -103,7 +104,7 @@ MODULE
    	 key = 0 400
   	 key = 1 400
  	}
-	
+
 }
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_625_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_625_01.cfg
@@ -11,20 +11,20 @@ MODEL
 {
 	model = UmbraSpaceIndustries/Karbonite/Assets/KA_SRB_01
 	texture = RATCan, UmbraSpaceIndustries/Karbonite/Assets/RATCan2
-	scale = .5,.5,.5	
+	scale = .5,.5,.5
 }
 MODEL
 {
 	model = UmbraSpaceIndustries/Karbonite/Assets/KA_SRB_01
 	texture = RATCan, UmbraSpaceIndustries/Karbonite/Assets/RATCan2
 	position = 0,0.625,0
-	scale = .5,.5,.5	
+	scale = .5,.5,.5
 }
 MODEL
 {
 	model = UmbraSpaceIndustries/Karbonite/Assets/KA_SRB_Nozzle
 	position = 0,-.3125,0
-	scale = .5,.5,.5	
+	scale = .5,.5,.5
 }
 rescaleFactor = 1
 
@@ -49,7 +49,8 @@ sound_explosion_low = flameout
 // --- editor parameters ---
 TechRequired = heavyRocketry
 entryCost = 1500
-cost = 150
+// cost = 150 (base cost) + 75 * 1.6 (max fuel * cost per unit)
+cost = 270
 category = Propulsion
 subcategory = 0
 title = RAT-625-A Karbonite SRB
@@ -67,7 +68,7 @@ maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 7
-maxTemp = 3600 
+maxTemp = 3600
 fuelCrossFeed = false
 
 stagingIcon = SOLID_BOOSTER
@@ -98,7 +99,7 @@ MODULE
    	 key = 0 400
   	 key = 1 400
  	}
-	
+
 }
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_625_02.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_SRB_625_02.cfg
@@ -25,20 +25,20 @@ MODEL
 	model = UmbraSpaceIndustries/Karbonite/Assets/KA_SRB_01
 	texture = RATCan, UmbraSpaceIndustries/Karbonite/Assets/RATCan2
 	position = 0,1.25,0
-	scale = .5,.5,.5	
+	scale = .5,.5,.5
 }
 MODEL
 {
 	model = UmbraSpaceIndustries/Karbonite/Assets/KA_SRB_01
 	texture = RATCan, UmbraSpaceIndustries/Karbonite/Assets/RATCan2
 	position = 0,1.875,0
-	scale = .5,.5,.5	
+	scale = .5,.5,.5
 }
 MODEL
 {
 	model = UmbraSpaceIndustries/Karbonite/Assets/KA_SRB_Nozzle
 	position = 0,-.3125,0
-	scale = .5,.5,.5	
+	scale = .5,.5,.5
 }
 rescaleFactor = 1
 
@@ -63,7 +63,8 @@ sound_explosion_low = flameout
 // --- editor parameters ---
 TechRequired = heavyRocketry
 entryCost = 1500
-cost = 150
+// cost = 150 (base cost) + 150 * 1.6 (max fuel * cost per unit)
+cost = 390
 category = Propulsion
 subcategory = 0
 title = RAT-625-B Karbonite SRB
@@ -81,7 +82,7 @@ maximum_drag = 0.3
 minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 7
-maxTemp = 3600 
+maxTemp = 3600
 fuelCrossFeed = false
 
 stagingIcon = SOLID_BOOSTER
@@ -112,7 +113,7 @@ MODULE
    	 key = 0 400
   	 key = 1 400
  	}
-	
+
 }
 
 MODULE

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_01/KA_Tank_125_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_01/KA_Tank_125_01.cfg
@@ -7,7 +7,7 @@ PART
 	author = Chris Adderley
 
 	// --- asset parameters ---
-	
+
 	scale = 1.0
 	rescaleFactor = 1
 
@@ -25,11 +25,12 @@ PART
 		texture = blank_a, UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/karbonite-125
 		texture = blank_NRM, UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/karbonite-125-n_NRM
 	}
-	
+
 	// --- editor parameters ---
 	TechRequired = heavyRocketry
 	entryCost = 1600
-	cost = 500
+	// cost = 500 (base cost) + 100 * 1.6 (max fuel * cost per unit)
+	cost = 660
 	category = Propulsion
 	subcategory = 0
 	title = KB-2500 Karbonite Tank

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_02/KA_Tank_125_02.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_02/KA_Tank_125_02.cfg
@@ -7,7 +7,7 @@ PART
 	author = Chris Adderley
 
 	// --- asset parameters ---
-	
+
 	scale = 1.0
 	rescaleFactor = 1
 
@@ -25,11 +25,12 @@ PART
 		texture = blank_a, UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/karbonite-125
 		texture = blank_NRM, UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/karbonite-125-n_NRM
 	}
-	
+
 	// --- editor parameters ---
 	TechRequired = heavyRocketry
 	entryCost = 1600
-	cost = 750
+	// cost = 750 (base cost) + 200 * 1.6 (max fuel * cost per unit)
+	cost = 1070
 	category = Propulsion
 	subcategory = 0
 	title = KB-3000 Karbonite Tank

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_03/KA_Tank_125_03.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_03/KA_Tank_125_03.cfg
@@ -7,7 +7,7 @@ PART
 	author = Chris Adderley
 
 	// --- asset parameters ---
-	
+
 	scale = 1.0
 	rescaleFactor = 1
 
@@ -25,11 +25,12 @@ PART
 		texture = blank_a, UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/karbonite-125
 		texture = blank_NRM, UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/karbonite-125-n_NRM
 	}
-	
+
 	// --- editor parameters ---
 	TechRequired = heavyRocketry
 	entryCost = 1600
-	cost = 1250
+	// cost = 1250 (base cost) + 400 * 1.6 (max fuel * cost per unit)
+	cost = 1890
 	category = Propulsion
 	subcategory = 0
 	title = KB-3650 Karbonite Tank

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/KA_Tank_125_04.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_125_04/KA_Tank_125_04.cfg
@@ -20,7 +20,8 @@ PART
 	// --- editor parameters ---
 	TechRequired = heavyRocketry
 	entryCost = 1600
-	cost = 2000
+	// cost = 2000 (base cost) + 800 * 1.6 (max fuel * cost per unit)
+	cost = 3280
 	category = Propulsion
 	subcategory = 0
 	title = KB-4650 Karbonite Tank

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_250_01/KA_Tank_250_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_250_01/KA_Tank_250_01.cfg
@@ -20,7 +20,8 @@ PART
 	// --- editor parameters ---
 	TechRequired = fuelSystems
 	entryCost = 1600
-	cost = 3500
+	// cost = 3500 (base cost) + 1450 * 1.6 (max fuel * cost per unit)
+	cost = 5820
 	category = Propulsion
 	subcategory = 0
 	title = KA-200 Karbonite Tank

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_Radial_01/KA_Tank_Radial_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_Radial_01/KA_Tank_Radial_01.cfg
@@ -10,7 +10,8 @@ node_attach = 0.0, 0.0, 0.15, 0.0, 0.0, 0.0
 
 TechRequired = aerodynamicSystems
 entryCost = 1600
-cost = 1000
+// cost = 1000 (base cost) + 350 * 1.6 (max fuel * cost per unit)
+cost = 1560
 category = Propulsion
 subcategory = 0
 title = KB-350R Karbonite Tank

--- a/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_VTS_01/KA_Tank_VTS_01.cfg
+++ b/GameData/UmbraSpaceIndustries/Karbonite/Parts/KA_Tank_VTS_01/KA_Tank_VTS_01.cfg
@@ -13,7 +13,8 @@ node_attach = 0.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0
 
 TechRequired = aerodynamicSystems
 entryCost = 200
-cost = 200
+// cost = 200 (base cost) + 40 * 1.6 (max fuel * cost per unit)
+cost = 264
 category = Propulsion
 subcategory = 0
 title = VTS Karbonite Tank
@@ -47,15 +48,15 @@ RESOURCE
 
 MODULE
 {
-name = KASModuleGrab            
+name = KASModuleGrab
 evaTransformName = jetpackCollider
-evaPartPos = (0.0, 0.4, -0.1)        
+evaPartPos = (0.0, 0.4, -0.1)
 evaPartDir = (0,-0.01,-0.1)
 //attachNodeName = bottom
 customGroundPos = true
-dropPartPos = (0.0, 1.0, 0.6)       
+dropPartPos = (0.0, 1.0, 0.6)
 dropPartRot = (0.0, 0.0, 0.0)
-//physicJoint = false 
+//physicJoint = false
 //addPartMass = true
 storable = false
 stateless = true


### PR DESCRIPTION
See issue #145.  The Cost of the Part in the config assumes the maxAmount of any fuel it contains. In game, it then subtracts the calculated cost of any fuel less than the max amount to get the real cost.  Currently all karbonite-fueld parts (that start with 0 fuel) have less than the intended price, and in some cases even negative price, because of this.