### PR TITLE
Update CTT.cfg

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/KarbonitePlus/CTT.cfg
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/KarbonitePlus/CTT.cfg
@@ -34,6 +34,14 @@
 {
     @TechRequired = exoticReactions
 }
+@PART[KA_Engine_125_03]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = exoticReactions
+}
+@PART[KA_Engine_250_03]:NEEDS[CommunityTechTree]
+{
+    @TechRequired = exoticReactions
+}
 @PART[KA_Engine_125_02]:NEEDS[CommunityTechTree]
 {
     @TechRequired = fusionRockets


### PR DESCRIPTION
The two smaller Torch drives had no entry in the CTT config.
This places them above the Karborundum fusion drives and in the same Exotic Fusion Reactions node as is populated by the larger two torch drives.

My first PR. I hope it is done right.