### PR TITLE
Add ReStock Whitelist file for Karbonite drill parts.

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karbonite/Karbonite.restockwhitelist
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/Karbonite/Karbonite.restockwhitelist
@@ -1,0 +1,4 @@
+// Whitelist to enable Karbonite parts when ReStock is installed.
+// See: https://github.com/PorktoberRevolution/ReStocked/wiki/Asset-Blacklist-and-Whitelist
+
+Squad/Parts/Resources/RadialDrill/


### PR DESCRIPTION
Whitelist the Vanilla TriBitDrill files to ensure that the Karbonite drill parts can load correctly alongside ReStock.